### PR TITLE
Add real-time preview toggle, theme switching, font size adjustment, …

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,35 +21,46 @@
         <option value="ember">🔥 Ember</option>
         <option value="magic">🌃 Magic</option>
       </select>
-      <button id="download-html">⬇️ Download as HTML</button>
+      <button id="download-html" aria-label="Download HTML">⬇️ Download as HTML</button>
     </div>
   </header>
+
   <div class="container">
     <div class="input-section">
       <div class="input-header">
         <h2>Markdown Input</h2>
-        <select id="font-size-selector">
-          <option value="16">Small</option>
-          <option value="18" selected>Medium</option>
-          <option value="20">Large</option>
-        </select>
+        <div class="controls">
+          <select id="font-size-selector" aria-label="Font Size Selector">
+            <option value="16">Small</option>
+            <option value="18" selected>Medium</option>
+            <option value="20">Large</option>
+          </select>
+          <label class="toggle-label">
+            <input type="checkbox" id="real-time-toggle">
+            <span class="slider"></span> Real-Time Preview
+          </label>
+        </div>
       </div>
-      <textarea id="markdown-input" placeholder="Type your Markdown here..."></textarea>
-      <button id="show-preview" class="primary-button">Show Preview</button>
+      <textarea id="markdown-input" placeholder="Type your Markdown here..." aria-label="Markdown Input"></textarea>
+      <button id="show-preview" class="primary-button" aria-label="Show Preview">Show Preview</button>
     </div>
     <div class="preview-section">
       <h2>Preview</h2>
-      <div id="preview"></div>
+      <div id="preview" aria-live="polite"></div>
     </div>
   </div>
+
   <footer>
     <p>Markdown Previewer &copy; <span id="year"></span> | Made with ❤️</p>
   </footer>
+
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
   <script>
-    const year = new Date().getFullYear();
-    document.getElementById('year').innerHTML=year;
+    // Set current year in footer
+    document.addEventListener("DOMContentLoaded", () => {
+      document.getElementById('year').textContent = new Date().getFullYear();
+    });
   </script>
 </body>
 </html>

--- a/src/script.js
+++ b/src/script.js
@@ -6,11 +6,23 @@ const showPreviewButton = document.getElementById('show-preview');
 const themeSelector = document.getElementById('theme-selector');
 const fontSizeSelector = document.getElementById('font-size-selector');
 const downloadButton = document.getElementById('download-html');
+const realTimeToggle = document.getElementById('real-time-toggle');
 
-// Render Markdown (only when button is clicked)
+// Utility: Debounce function for performance optimization (real-time preview)
+function debounce(func, delay = 300) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), delay);
+  };
+}
 function renderMarkdown() {
   const markdownText = markdownInput.value;
-  preview.innerHTML = marked.parse(markdownText);
+  try {
+    preview.innerHTML = marked.parse(markdownText) || '<p>No content to preview</p>';
+  } catch (error) {
+    preview.innerHTML = `<p style="color: red;">Error rendering markdown: ${error.message}</p>`;
+  }
 }
 
 // Theme Switcher
@@ -18,18 +30,19 @@ themeSelector.addEventListener('change', (e) => {
   document.body.className = `theme-${e.target.value}`;
 });
 
-// Font Size Adjuster
-fontSizeSelector.addEventListener('change', (e) => {
-  const fontSize = `${e.target.value}px`;
+function applyTheme(theme) {
+  document.body.className = `theme-${theme}`;
+}
+
+// Adjust Font Size
+function adjustFontSize(size) {
+  const fontSize = `${size}px`;
   markdownInput.style.fontSize = fontSize;
   preview.style.fontSize = fontSize;
-});
+}
 
-// Show Preview on Button Click
-showPreviewButton.addEventListener('click', renderMarkdown);
-
-// Download HTML
-downloadButton.addEventListener('click', () => {
+// Download Preview as HTML
+function downloadPreview() {
   const blob = new Blob([preview.innerHTML], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -37,4 +50,38 @@ downloadButton.addEventListener('click', () => {
   a.download = 'markdown-preview.html';
   a.click();
   URL.revokeObjectURL(url);
-});
+}
+
+// Toggle Preview Mode (Real-Time vs Manual)
+function togglePreviewMode(isRealTime) {
+  if (isRealTime) {
+    markdownInput.addEventListener('input', debouncedRenderMarkdown);
+    showPreviewButton.style.display = 'none'; 
+  } else {
+    markdownInput.removeEventListener('input', debouncedRenderMarkdown);
+    showPreviewButton.style.display = 'inline-block'; // Show manual preview button
+  }
+}
+
+
+function attachEventListeners() {
+  // Manual Preview Button
+  showPreviewButton.addEventListener('click', renderMarkdown);
+
+  // Theme Selector
+  themeSelector.addEventListener('change', (e) => applyTheme(e.target.value));
+  fontSizeSelector.addEventListener('change', (e) => adjustFontSize(e.target.value));
+  downloadButton.addEventListener('click', downloadPreview);
+  realTimeToggle.addEventListener('change', (e) => togglePreviewMode(e.target.checked));
+}
+
+const debouncedRenderMarkdown = debounce(renderMarkdown, 200);
+
+function initializeApp() {
+  attachEventListeners();
+  applyTheme(themeSelector.value);
+  adjustFontSize(fontSizeSelector.value);
+  togglePreviewMode(false);
+}
+
+document.addEventListener('DOMContentLoaded', initializeApp);

--- a/src/styles.css
+++ b/src/styles.css
@@ -354,4 +354,43 @@ body, h1, h2, p, button, select, textarea, div {
       padding: 8px;
     }
   }
-  
+  /* Toggle Switch Styles */
+.toggle-label {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 1rem;
+  cursor: pointer;
+}
+
+.toggle-label input {
+  display: none; /* Hide checkbox */
+}
+
+.toggle-label .slider {
+  width: 40px;
+  height: 20px;
+  background-color: #ccc;
+  border-radius: 15px;
+  position: relative;
+  transition: background-color 0.3s;
+}
+
+.toggle-label .slider::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  background-color: #fff;
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  transition: transform 0.3s;
+}
+
+.toggle-label input:checked + .slider {
+  background-color: #4caf50;
+}
+
+.toggle-label input:checked + .slider::before {
+  transform: translateX(20px);
+}


### PR DESCRIPTION
This pull request adds several enhancements to the Markdown Previewer app, including a real-time preview toggle for instant updates while typing, and a manual preview mode with a button. Users can now switch between different themes and adjust font sizes for both the input and preview areas. Additionally, a download button allows users to save the preview as an HTML file. Error handling for Markdown rendering has also been improved.