### PR TITLE
Remove "Download as HTML" option from About page

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -46,9 +46,6 @@
     <header>
         <a href="index.html"><h1>Markdown Previewer</h1></a>
         <div class="header-actions">
-          <nav>
-            <a href="about.html">About</a>
-          </nav>
           <select id="theme-selector">
             <option value="light">🌞 Light</option>
             <option value="dark">🌙 Dark</option>
@@ -59,7 +56,6 @@
             <option value="ember">🔥 Ember</option>
             <option value="magic">🌃 Magic</option>
           </select>
-          <button id="download-html">⬇️ Download as HTML</button>
         </div>
       </header>
       <!-- about section -->


### PR DESCRIPTION
**## Description :**
This pull request addresses the issue of removing the download button from the about page. The following changes have been made:
- Removed the download button from the about page HTML.
- 
**## Changes :**
- **about.html**: Removed the download button and related styles.

**## Related Issues :** 
- Closes #37 

Thanks @Jyotibrat for assigning me on this issue.

![image](https://github.com/user-attachments/assets/ea024ffc-5980-4b40-9bce-fd6003febc05)
