### PR TITLE
clicking on read more button in vision section now leads to vision page

### DIFF
--- a/src/blog.html
+++ b/src/blog.html
@@ -31,7 +31,7 @@
             <div class="info">
                 <h1>Vision</h1>
                 <p>We envision MarkView as the go-to platform for Markdown editing, with continuous improvements, customizable themes, and seamless integration with various platforms. Our goal is to make Markdown writing intuitive and accessible for everyone.As we progress, we aim to create a collaborative ecosystem where users can share their Markdown documents, get feedback, and work together on projects effortlessly. We see MarkView as a tool that not only simplifies Markdown editing but also enhances the overall writing experience.</p>
-                <button onclick="location.href='blog1.html'">Read more</button>
+                <button onclick="location.href='blog2.html'">Read more</button>
             </div>
         </div> 
 


### PR DESCRIPTION
Now the user will land to the vision blog page only after clicking the read more button in vision section.
Issue No.: #119 