### PR TITLE
Navbar link updated

### DIFF
--- a/src/navbar.html
+++ b/src/navbar.html
@@ -42,13 +42,13 @@
                         <i class="fas fa-file-alt"></i> Markdown
                     </button>
                     <div class="dropdown-menu">
-                        <a href="markdown_live_preview.html">Live Preview</a>
+                        <a href="index.html">Live Preview</a>
                         <a href="file_upload.html">Upload</a>
                     </div>
                 </div>
-                <a href="html_previewer.html">
+                <a href="Html_Previewer.html">
                     <i class="fab fa-html5"></i> HTML
-                </a>
+                </a>    
                 <div class="dropdown">
                     <button class="dropdown-toggle">
                         <i class="fas fa-code"></i> Online IDE


### PR DESCRIPTION
- the html previewer page was not correctly spelled
- the markdown live preview was linking to wrong page